### PR TITLE
Support notebook execution on smaller devices

### DIFF
--- a/notebooks/T2I_sampling.ipynb
+++ b/notebooks/T2I_sampling.ipynb
@@ -25,7 +25,13 @@
     "you can input various texts to generate the corresponded images.  \n",
     "\n",
     "You can certainly adjust the sampling parameters such as `temperature`, `top_k`, and `top_p` for better quality of generated images according to the given texts.  \n",
-    "As the three parameters have lower values than the default setting, you can get more simple and confident images, and vice versa."
+    "As the three parameters have lower values than the default setting, you can get more simple and confident images, and vice versa.\n",
+    "\n",
+    "### Execution on local machines\n",
+    "If running locally on a smaller device with enough memory to load the model (e.g. RTX 3090,) first make the following changes:\n",
+    "1. Add `map_location='cuda'` to both `load_model` calls in step 2.\n",
+    "2. Reduce the `num_samples` in step 3 to meet your memory constraints.\n",
+    "3. Add `amp=False` to the `get_generated_images_by_texts` call in step 4."
    ]
   },
   {

--- a/notebooks/notebook_utils.py
+++ b/notebooks/notebook_utils.py
@@ -52,16 +52,16 @@ class TextEncoder:
         return self.encode(texts)
     
 
-def load_model(path, ema=False):
+def load_model(path, ema=False, map_location='cpu'):
     model_config = os.path.join(os.path.dirname(path), 'config.yaml')
     config = load_config(model_config)
     config.arch = augment_arch_defaults(config.arch)
 
     model, _ = create_model(config.arch, ema=False)
     if ema:
-        ckpt = torch.load(path, map_location='cpu')['state_dict_ema']
+        ckpt = torch.load(path, map_location=map_location)['state_dict_ema']
     else:
-        ckpt = torch.load(path, map_location='cpu')['state_dict']
+        ckpt = torch.load(path, map_location=map_location)['state_dict']
     model.load_state_dict(ckpt)
 
     return model, config


### PR DESCRIPTION
I was able to get the full-size parameter set working locally on my personal dev machine (16 samples on a RTX 3090,) but I had to disable mixed precision and specify map_location as `cuda`. A few people on reddit suggested that they'd like to be able to do the same, so I added some support for it in the notebook utils and notes in the notebook itself.

I've not worked with pytorch in enough different environments to know why exactly having the default map_location be `cpu` didn't work for me, so I tried to be unintrusive and left the default for the notebook as `cpu`. If you want to change it to `cuda` by default - I don't know the positives/negatives of each other than that `cpu` wasn't working on my machine - I can modify this PR to do that instead.